### PR TITLE
表示件数の上限を撤廃

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,108 +1,120 @@
 <!doctype html>
 <html>
+
 <head>
 	<title>筑波大学 KdBっぽいなにか</title>
 	<meta charset="utf-8">
-	<link href="style.css" rel="stylesheet"/>
-	<script src="script.js"/></script>
+	<link href="style.css" rel="stylesheet" />
+	<script src="script.js"></script>
 </head>
 
 <body>
-<header>
-	<div class="content"><form>
-		<p>
-			<span class="h4">科目名</span><input type="text"/> <a href="#" id="submit"/>検索</a>
-		</p>
-		<p>
-			<span class="h4">要件</span><!--
-			--><select id="req_A">
-				<option value="null">指定なし</option>
-				<option>フレッシュマン・セミナー</option>
-				<option>学問への誘い</option>
-				<option>学士基盤科目</option>
-				<option>体育</option>
-				<option>外国語（英語）</option>
-				<option>外国語（ドイツ語）</option>
-				<option>外国語（フランス語）</option>
-				<option>外国語（中国語）</option>
-				<option>外国語（ロシア語）</option>
-				<option>外国語（スペイン語）</option>
-				<option>外国語（朝鮮語）</option>
-				<option>外国語（日本語、Japan-Expert（学士）プログラム）</option>
-				<option>外国語外国語（短期留学生用カリキュラム）</option>
-				<option>情報</option>
-				<option>国語</option>
-				<option>芸術</option>
-				<option>自由科目（特設）</option>
-				<option>教職に関する科目</option>
-				<option>博物館に関する科目</option>
-				<option>日本事情等科目</option>
-				<option>人文・文化学群</option>
-				<option>社会・国際学群</option>
-				<option>人間学群</option>
-				<option>生命環境学群</option>
-				<option>理工学群</option>
-				<option>情報学群</option>
-				<option>医学群</option>
-				<option>体育専門学群</option>
-				<option>芸術専門学群</option>
-				<option>グローバル教育院　地球規模課題学位プログラム</option>
-				<option>English Courses</option>
-			</select><!--
-			--><select>
-			</select>
-		</p>
-		</p>
-		<p>
-			<span class="h4">学期</span>
-			<label><input type="radio" name="season" value="null" checked>―</label>
-			<label><input type="radio" name="season" value="春">春</label>
-			<label><input type="radio" name="season" value="秋">秋</label>
-			／
-			<label><input type="radio" name="module" value="null" checked>―</label>
-			<label><input type="radio" name="module" value="A">A</label>
-			<label><input type="radio" name="module" value="B">B</label>
-			<label><input type="radio" name="module" value="C">C</label>
-		</p>
-		<p>
-			<span class="h4">時限</span>
-			<label><input type="radio" name="day" value="null" checked>―</label>
-			<label><input type="radio" name="day" value="月">月</label>
-			<label><input type="radio" name="day" value="火">火</label>
-			<label><input type="radio" name="day" value="水">水</label>
-			<label><input type="radio" name="day" value="木">木</label>
-			<label><input type="radio" name="day" value="金">金</label>
-			<label><input type="radio" name="day" value="土">土</label>
-			<label><input type="radio" name="day" value="日">日</label>
-			／
-			<label><input type="radio" name="period" value="null" checked>―</label>
-			<label><input type="radio" name="period" value="1">1</label>
-			<label><input type="radio" name="period" value="2">2</label>
-			<label><input type="radio" name="period" value="3">3</label>
-			<label><input type="radio" name="period" value="4">4</label>
-			<label><input type="radio" name="period" value="5">5</label>
-			<label><input type="radio" name="period" value="5">6</label>
-		</p>
-		<p>
-			<span class="h4">実施形態</span>
-			<label><input type="radio" name="online" value="null" checked>―</label>
-			<label><input type="radio" name="online" value="対面">対面</label>
-			<label><input type="radio" name="online" value="オンデマンド">オンデマンド</label>
-			<label><input type="radio" name="online" value="同時双方向">同時双方向</label>
-		</p>
-	</form></div>
-</header>
+	<header>
+		<div class="content">
+			<form>
+				<p>
+					<span class="h4">科目名</span><input type="text" /> <a href="#" id="submit">検索</a>
+				</p>
+				<p>
+					<span class="h4">要件</span>
+					<select id="req_A">
+						<option value="null">指定なし</option>
+						<option>フレッシュマン・セミナー</option>
+						<option>学問への誘い</option>
+						<option>学士基盤科目</option>
+						<option>体育</option>
+						<option>外国語（英語）</option>
+						<option>外国語（ドイツ語）</option>
+						<option>外国語（フランス語）</option>
+						<option>外国語（中国語）</option>
+						<option>外国語（ロシア語）</option>
+						<option>外国語（スペイン語）</option>
+						<option>外国語（朝鮮語）</option>
+						<option>外国語（日本語、Japan-Expert（学士）プログラム）</option>
+						<option>外国語外国語（短期留学生用カリキュラム）</option>
+						<option>情報</option>
+						<option>国語</option>
+						<option>芸術</option>
+						<option>自由科目（特設）</option>
+						<option>教職に関する科目</option>
+						<option>博物館に関する科目</option>
+						<option>日本事情等科目</option>
+						<option>人文・文化学群</option>
+						<option>社会・国際学群</option>
+						<option>人間学群</option>
+						<option>生命環境学群</option>
+						<option>理工学群</option>
+						<option>情報学群</option>
+						<option>医学群</option>
+						<option>体育専門学群</option>
+						<option>芸術専門学群</option>
+						<option>グローバル教育院　地球規模課題学位プログラム</option>
+						<option>English Courses</option>
+					</select>
+					<select>
+					</select>
+				</p>
+				</p>
+				<p>
+					<span class="h4">学期</span>
+					<label><input type="radio" name="season" value="null" checked>―</label>
+					<label><input type="radio" name="season" value="春">春</label>
+					<label><input type="radio" name="season" value="秋">秋</label>
+					／
+					<label><input type="radio" name="module" value="null" checked>―</label>
+					<label><input type="radio" name="module" value="A">A</label>
+					<label><input type="radio" name="module" value="B">B</label>
+					<label><input type="radio" name="module" value="C">C</label>
+				</p>
+				<p>
+					<span class="h4">時限</span>
+					<label><input type="radio" name="day" value="null" checked>―</label>
+					<label><input type="radio" name="day" value="月">月</label>
+					<label><input type="radio" name="day" value="火">火</label>
+					<label><input type="radio" name="day" value="水">水</label>
+					<label><input type="radio" name="day" value="木">木</label>
+					<label><input type="radio" name="day" value="金">金</label>
+					<label><input type="radio" name="day" value="土">土</label>
+					<label><input type="radio" name="day" value="日">日</label>
+					／
+					<label><input type="radio" name="period" value="null" checked>―</label>
+					<label><input type="radio" name="period" value="1">1</label>
+					<label><input type="radio" name="period" value="2">2</label>
+					<label><input type="radio" name="period" value="3">3</label>
+					<label><input type="radio" name="period" value="4">4</label>
+					<label><input type="radio" name="period" value="5">5</label>
+					<label><input type="radio" name="period" value="5">6</label>
+				</p>
+				<p>
+					<span class="h4">実施形態</span>
+					<label><input type="radio" name="online" value="null" checked>―</label>
+					<label><input type="radio" name="online" value="対面">対面</label>
+					<label><input type="radio" name="online" value="オンデマンド">オンデマンド</label>
+					<label><input type="radio" name="online" value="同時双方向">同時双方向</label>
+				</p>
+			</form>
+		</div>
+	</header>
 
-<div id="page">
-	<main>
-		<table>
-			<tr><th>科目番号<br>科目名</th><th>単位<br>年次</th><th>学期<br>時期</th>
-			<th>教室</th><th>担当</th><th>実施形態</th><th>概要</th><th>備考</th></tr>
-		</table>
-	</main>
-	<footer>
-		(c) いなにわうどん - <a href="https://twitter.com/kyoto_mast21">@kyoto_mast21</a>
-	</footer>
-</div>
+	<div id="page">
+		<main>
+			<table>
+				<tr>
+					<th>科目番号<br>科目名</th>
+					<th>単位<br>年次</th>
+					<th>学期<br>時期</th>
+					<th>教室</th>
+					<th>担当</th>
+					<th>実施形態</th>
+					<th>概要</th>
+					<th>備考</th>
+				</tr>
+			</table>
+		</main>
+		<footer>
+			(c) いなにわうどん - <a href="https://twitter.com/kyoto_mast21">@kyoto_mast21</a>
+		</footer>
+	</div>
 </body>
+
 </html>

--- a/script.js
+++ b/script.js
@@ -1,112 +1,89 @@
-var data;
-var table;
-var keyword_input;
-var form;
-var req_A_input;
+window.onload = function () {
+  const table = document.querySelector("main table");
+  const keyword_input = document.querySelector("input[type=\"text\"]");
+  const form = document.getElementsByTagName("form")[0];
+  const req_A_input = document.getElementById("req_A");
+  let data = null;
+  let timeout = void 0;
 
-window.onload = function()
-{
-	table = document.querySelector("main table");
-	keyword_input = document.querySelector("input[type=\"text\"]");
-	form = document.getElementsByTagName("form")[0];
-	req_A_input = document.getElementById("req_A");
+  const createLine = (line) => {
+    let tr = document.createElement("tr");
+    table.appendChild(tr);
 
-	let submit = document.getElementById("submit");
-	submit.onclick = search;
+    let url = `https://kdb.tsukuba.ac.jp/syllabi/2021/${line[0]}/jpn`;
+    let methods = ["対面", "オンデマンド", "同時双方向"].filter(it => line[10].indexOf(it) > -1);
 
-	fetch("kdb.json")
-		.then(response => response.json())
-		.then(json => { data = json; search(null, 7); })
+    tr.innerHTML += `<td>${line[0]}<br/>${line[1]}<br/><a href="${url}" class="syllabus" target="_blank">シラバス</a></td>`;
+    tr.innerHTML += `<td>${line[3]}単位<br/>${line[4]}年次</td>`;
+    tr.innerHTML += `<td>${line[5]}<br/>${line[6]}</td>`;
+    tr.innerHTML += `<td>${line[7].replace(/,/g, "<br/>")}</td>`;
+    tr.innerHTML += `<td>${line[8].replace(/,/g, "<br/>")}</td>`;
+    tr.innerHTML += `<td>${line[9]}</td>`;
+
+    if (methods.length < 1) {
+      tr.innerHTML += "<td>不詳</td>"
+    } else {
+      tr.innerHTML += `<td>${methods.join('<br />')}<br /></td>`;
+    }
+  }
+
+  const updateTable = (options, data, index, continuous) => {
+    index = index || 0;
+    const line = data[index];
+    let matchesSeason = options.season != "null" && line[5].indexOf(season) < 0;
+    let matchesModule = options.module_ != "null" && line[5].indexOf(module_) < 0;
+    let matchesDay = options.day != "null" && line[6].indexOf(day) < 0;
+    let matchesPeriod = options.period != "null" && line[6].indexOf(period) < 0;
+
+    if (typeof line === 'undefined') {
+      clearTimeout(timeout);
+      timeout = void 0;
+    }
+
+    if (!continuous && typeof timeout !== 'undefined') {
+      clearTimeout(timeout);
+    }
+
+
+    if (
+      (options.keyword != "" && line[1].indexOf(options.keyword) < 0) ||
+      matchesSeason ||
+      matchesModule ||
+      matchesDay ||
+      matchesPeriod ||
+      (options.online != "null" && line[10].indexOf(options.online) < 0) ||
+      (options.req_A != "null" && options.req_A != line[12])) {
+      timeout = setTimeout(updateTable(index + 1, true), 0);
+      return;
+    }
+
+    createLine(line);
+
+    timeout = setTimeout(updateTable(index + 1, true), 0);
+  }
+
+  const search = (_) => {
+
+    let options = {};
+
+    options.keyword = keyword_input.value;
+    options.req_A = req_A_input.options[req_A_input.selectedIndex].value;
+    options.season = form.season.value;
+    options.module_ = form.module.value;
+    options.day = form.day.value;
+    options.period = form.period.value;
+    options.online = form.online.value;
+
+    table.innerHTML = `<tr><th>科目番号<br>科目名</th><th>単位<br>年次</th>
+      <th>学期<br>時期</th><th>教室</th><th>担当</th><th>実施形態</th><th>概要</th><th>備考</th></tr>`;
+
+    updateTable(options, data);
+  }
+
+  let submit = document.getElementById("submit");
+  submit.onclick = search;
+
+  fetch("kdb.json")
+    .then(response => response.json())
+    .then(json => { data = json; search(null, 7); })
 };
-
-
-function search(e, no)
-{
-	no = no == null ? 100 : no;
-
-	let keyword = keyword_input.value;
-	let req_A = req_A_input.options[req_A_input.selectedIndex].value;
-	let season = form.season.value;
-	let module_ = form.module.value;
-	let day = form.day.value;
-	let period = form.period.value;
-	let online = form.online.value;
-
-	let choosen = [];
-	
-	for (let line of data) {
-		if (keyword != "" && line[1].indexOf(keyword) < 0)
-			continue;
-
-		let matchesSeason = season != "null" && line[5].indexOf(season) < 0;
-		let matchesModule = module_ != "null" && line[5].indexOf(module_) < 0;
-		if (matchesSeason || matchesModule)
-			continue;
-
-		let matchesDay = day != "null" && line[6].indexOf(day) < 0;
-		let matchesPeriod = period != "null" && line[6].indexOf(period) < 0;
-		if (matchesDay || matchesPeriod)
-			continue;
-
-		if (online != "null" && line[10].indexOf(online) < 0)
-			continue;
-		console.log(online);
-
-		if (req_A != "null" && req_A != line[12])
-			continue;
-
-		choosen.push(line);
-
-		if (choosen.length > no)
-			break;
-	}
-
-	table.innerHTML = `<tr><th>科目番号<br>科目名</th><th>単位<br>年次</th>
-		<th>学期<br>時期</th><th>教室</th><th>担当</th><th>実施形態</th><th>概要</th><th>備考</th></tr>`;
-
-	for (let i = 0; i < Math.min(choosen.length, no); i++) {
-		let tr = document.createElement("tr");
-		table.appendChild(tr);
-
-		for (let x = 0; x < 11; x++) {
-			let td = document.createElement("td");
-			let url = "https://kdb.tsukuba.ac.jp/syllabi/2021/" + choosen[i][0] + "/jpn";
-
-			if (x == 9) {
-				let td2 = document.createElement("td");
-				let existsMethods = false;
-				let methods = ["対面", "オンデマンド", "同時双方向"]
-
-				for (let method of methods) {
-					if (choosen[i][10].indexOf(method) > -1) {
-						if (existsMethods)
-							td2.innerHTML += "<br/>";
-						td2.innerHTML += method;
-						existsMethods = true;
-					}
-				}
-				if (!existsMethods)
-					td2.innerHTML = "不詳";
-
-				tr.appendChild(td2);
-			}
-
-			if (x == 1 || x == 2 || x == 4 || x == 6)
-				continue;			
-
-			else if (x == 0 || x == 5)
-				td.innerHTML = choosen[i][x] + "<br/>" + choosen[i][x+1];
-			else if (x == 3)
-				td.innerHTML = choosen[i][x] + "単位<br/>" + choosen[i][x+1] + "年次";
-			else if (x == 7 || x == 8)
-				td.innerHTML = choosen[i][x].replace(/,/g, "<br/>");
-			else
-				td.innerHTML = choosen[i][x];
-
-			if (x == 0)
-				td.innerHTML += "<br/><a href=\"" + url + "\" class=\"syllabus\" target=\"_blank\">シラバス</a>";
-
-			tr.appendChild(td);
-		}
-	}
-}

--- a/script.js
+++ b/script.js
@@ -1,89 +1,93 @@
 window.onload = function () {
-  const table = document.querySelector("main table");
-  const keyword_input = document.querySelector("input[type=\"text\"]");
-  const form = document.getElementsByTagName("form")[0];
-  const req_A_input = document.getElementById("req_A");
-  let data = null;
-  let timeout = void 0;
+	const table = document.querySelector("main table");
+	const keyword_input = document.querySelector("input[type=\"text\"]");
+	const form = document.getElementsByTagName("form")[0];
+	const req_A_input = document.getElementById("req_A");
 
-  const createLine = (line) => {
-    let tr = document.createElement("tr");
-    table.appendChild(tr);
+	let data = null;
+	let timeout = void 0;
 
-    let url = `https://kdb.tsukuba.ac.jp/syllabi/2021/${line[0]}/jpn`;
-    let methods = ["対面", "オンデマンド", "同時双方向"].filter(it => line[10].indexOf(it) > -1);
+	const createLine = (line) => {
+		let tr = document.createElement("tr");
+		table.appendChild(tr);
 
-    tr.innerHTML += `<td>${line[0]}<br/>${line[1]}<br/><a href="${url}" class="syllabus" target="_blank">シラバス</a></td>`;
-    tr.innerHTML += `<td>${line[3]}単位<br/>${line[4]}年次</td>`;
-    tr.innerHTML += `<td>${line[5]}<br/>${line[6]}</td>`;
-    tr.innerHTML += `<td>${line[7].replace(/,/g, "<br/>")}</td>`;
-    tr.innerHTML += `<td>${line[8].replace(/,/g, "<br/>")}</td>`;
-    tr.innerHTML += `<td>${line[9]}</td>`;
+		let url = `https://kdb.tsukuba.ac.jp/syllabi/2021/${line[0]}/jpn`;
+		let methods = ["対面", "オンデマンド", "同時双方向"].filter(it => line[10].indexOf(it) > -1);
 
-    if (methods.length < 1) {
-      tr.innerHTML += "<td>不詳</td>"
-    } else {
-      tr.innerHTML += `<td>${methods.join('<br />')}<br /></td>`;
-    }
-  }
+		tr.innerHTML += `<td>${line[0]}<br/>${line[1]}<br/><a href="${url}" class="syllabus" target="_blank">シラバス</a></td>`;
+		tr.innerHTML += `<td>${line[3]}単位<br/>${line[4]}年次</td>`;
+		tr.innerHTML += `<td>${line[5]}<br/>${line[6]}</td>`;
+		tr.innerHTML += `<td>${line[7].replace(/,/g, "<br/>")}</td>`;
+		tr.innerHTML += `<td>${line[8].replace(/,/g, "<br/>")}</td>`;
 
-  const updateTable = (options, data, index, continuous) => {
-    index = index || 0;
-    const line = data[index];
-    let matchesSeason = options.season != "null" && line[5].indexOf(season) < 0;
-    let matchesModule = options.module_ != "null" && line[5].indexOf(module_) < 0;
-    let matchesDay = options.day != "null" && line[6].indexOf(day) < 0;
-    let matchesPeriod = options.period != "null" && line[6].indexOf(period) < 0;
+		if (methods.length < 1) {
+			tr.innerHTML += "<td>不詳</td>"
+		} else {
+			tr.innerHTML += `<td>${methods.join('<br />')}<br /></td>`;
+		}
 
-    if (typeof line === 'undefined') {
-      clearTimeout(timeout);
-      timeout = void 0;
-    }
+		tr.innerHTML += `<td>${line[9]}</td>`;
+	}
 
-    if (!continuous && typeof timeout !== 'undefined') {
-      clearTimeout(timeout);
-    }
+	const updateTable = (options, index, continuous) => {
+		index = index || 0;
+		const line = data[index];
 
+		if (typeof line === 'undefined') {
+			clearTimeout(timeout);
+			timeout = void 0;
+			return;
+		}
 
-    if (
-      (options.keyword != "" && line[1].indexOf(options.keyword) < 0) ||
-      matchesSeason ||
-      matchesModule ||
-      matchesDay ||
-      matchesPeriod ||
-      (options.online != "null" && line[10].indexOf(options.online) < 0) ||
-      (options.req_A != "null" && options.req_A != line[12])) {
-      timeout = setTimeout(updateTable(index + 1, true), 0);
-      return;
-    }
+		if (!continuous && typeof timeout !== 'undefined') {
+			clearTimeout(timeout);
+		}
 
-    createLine(line);
+		let matchesSeason = options.season != "null" && line[5].indexOf(options.season) < 0;
+		let matchesModule = options.module_ != "null" && line[5].indexOf(options.module_) < 0;
+		let matchesDay = options.day != "null" && line[6].indexOf(options.day) < 0;
+		let matchesPeriod = options.period != "null" && line[6].indexOf(options.period) < 0;
 
-    timeout = setTimeout(updateTable(index + 1, true), 0);
-  }
+		if (
+			(options.keyword != "" && line[1].indexOf(options.keyword) < 0) ||
+			matchesSeason ||
+			matchesModule ||
+			matchesDay ||
+			matchesPeriod ||
+			(options.online != "null" && line[10].indexOf(options.online) < 0) ||
+			(options.req_A != "null" && options.req_A != line[12])) {
+			timeout = setTimeout(() => updateTable(options, index + 1, true), 0);
+			return;
+		}
 
-  const search = (_) => {
+		createLine(line);
 
-    let options = {};
+		timeout = setTimeout(() => updateTable(options, index + 1, true), 10);
+	}
 
-    options.keyword = keyword_input.value;
-    options.req_A = req_A_input.options[req_A_input.selectedIndex].value;
-    options.season = form.season.value;
-    options.module_ = form.module.value;
-    options.day = form.day.value;
-    options.period = form.period.value;
-    options.online = form.online.value;
+	const search = (_) => {
 
-    table.innerHTML = `<tr><th>科目番号<br>科目名</th><th>単位<br>年次</th>
+		let options = {};
+
+		options.keyword = keyword_input.value;
+		options.req_A = req_A_input.options[req_A_input.selectedIndex].value;
+		options.season = form.season.value;
+		options.module_ = form.module.value;
+		options.day = form.day.value;
+		options.period = form.period.value;
+		options.online = form.online.value;
+
+		table.innerHTML = `<tr><th>科目番号<br>科目名</th><th>単位<br>年次</th>
       <th>学期<br>時期</th><th>教室</th><th>担当</th><th>実施形態</th><th>概要</th><th>備考</th></tr>`;
 
-    updateTable(options, data);
-  }
+		console.log(data);
+		updateTable(options);
+	}
 
-  let submit = document.getElementById("submit");
-  submit.onclick = search;
+	let submit = document.getElementById("submit");
+	submit.onclick = search;
 
-  fetch("kdb.json")
-    .then(response => response.json())
-    .then(json => { data = json; search(null, 7); })
+	fetch("kdb.json")
+		.then(response => response.json())
+		.then(json => { data = json; search(null, 7); })
 };

--- a/style.css
+++ b/style.css
@@ -103,3 +103,8 @@ footer {
 	text-align: center;
 	margin-top: 1rem;
 }
+
+form {
+	position: sticky;
+	top: 0;
+}


### PR DESCRIPTION
表示件数の上限が100件に制限されていましたが、その制限をなくしました。

表示件数の上限を増やしたことにより、検索メニューにアクセスしづらくなることが考えられますが、フォームに`position: sticky`を指定することで常に画面の最上部に表示されるようにしました。

また、for文で連続的に画面を更新していたため、多くの行を表示しようとするとUIスレッドが固まってしまう問題がありましたが、検索と更新を非同期に行うことでその問題を解消しました。

意図が良くわからないコードが散見されたので、リファクタリングも行いました。