### PR TITLE
`シラバス`の削除 / 改行の許容

### DIFF
--- a/script.js
+++ b/script.js
@@ -124,7 +124,7 @@ window.onload = function () {
 		for (r=0;  r<table_.rows.length; r++) {
 			row.length = 0;
 			for (c=0; c<table_.rows[r].cells.length; c++) {
-				field = table_.rows[r].cells[c].innerText;
+				field = table_.rows[r].cells[c].innerText.trim();
 				if (r !== 0 && c === 0) {
 					field = field.slice(0,-5);
 				}

--- a/script.js
+++ b/script.js
@@ -124,9 +124,9 @@ window.onload = function () {
 		for (r=0;  r<table_.rows.length; r++) {
 			row.length = 0;
 			for (c=0; c<table_.rows[r].cells.length; c++) {
-				field = table_.rows[r].cells[c].textContent;
+				field = table_.rows[r].cells[c].innerText;
 				if (r !== 0 && c === 0) {
-					field = field.slice(0,-4);
+					field = field.slice(0,-5);
 				}
 				row.push(escaped.test(field)? '"' + field.replace(e, '""') + '"' : field);
 		 	}

--- a/script.js
+++ b/script.js
@@ -125,6 +125,9 @@ window.onload = function () {
 			row.length = 0;
 			for (c=0; c<table_.rows[r].cells.length; c++) {
 				field = table_.rows[r].cells[c].textContent;
+				if (r !== 0 && c == 0) {
+					field = field.slice(0,-4);
+				}
 				row.push(escaped.test(field)? '"'+field.replace(e, '""')+'"': field);
 		 	}
 			csv.push(row.join(','));

--- a/script.js
+++ b/script.js
@@ -67,7 +67,7 @@ window.onload = function () {
 
 		index = typeof index === 'undefined' ? 0 : index;
 		displayedIndex = typeof displayedIndex === "undefined" ? 0 : displayedIndex;
-		
+
 		if (isIOS && displayedIndex >= lineLimit)
 			return;
 
@@ -125,18 +125,18 @@ window.onload = function () {
 			row.length = 0;
 			for (c=0; c<table_.rows[r].cells.length; c++) {
 				field = table_.rows[r].cells[c].textContent;
-				if (r !== 0 && c == 0) {
+				if (r !== 0 && c === 0) {
 					field = field.slice(0,-4);
 				}
-				row.push(escaped.test(field)? '"'+field.replace(e, '""')+'"': field);
+				row.push(escaped.test(field)? '"' + field.replace(e, '""') + '"' : field);
 		 	}
 			csv.push(row.join(','));
 		}
 		var blob = new Blob([bom, csv.join('\n')], {'type': 'text/csv'});
-	  
+
 		if (window.navigator.msSaveBlob) {
 			// IE
-			window.navigator.msSaveBlob(blob, filename); 
+			window.navigator.msSaveBlob(blob, filename);
 		} else {
 			a.download = filename;
 			a.href = window.URL.createObjectURL(blob);
@@ -161,7 +161,7 @@ window.onload = function () {
 
 		return Y + M + D + h + m + d;
 	  }
-	
+
 	// search
 	const search = (e) => {
 		while (table.firstChild) {


### PR DESCRIPTION
CSV1カラムに入っていた余計な文字の削除を行いました。
「科目番号／科目名」、「単位／年次」、「学期／時期」の分離は仕様とするかどうか…
現状はtableを素直にCSV変換したままです。